### PR TITLE
CLI - Support a base directory and a pattern with which to find tests as arguments.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@macarie/batch": "^1.2.1",
         "kleur": "^4.1.4",
-        "sade": "^1.7.4"
+        "sade": "^1.7.4",
+        "totalist": "^2.0.0"
       },
       "bin": {
         "test-please": "dist/bin/bin.js"
@@ -7637,6 +7638,14 @@
         "ret": "~0.1.10"
       }
     },
+    "node_modules/totalist": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
+      "integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/trim-newlines": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
@@ -13888,6 +13897,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "totalist": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
+      "integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ=="
     },
     "trim-newlines": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "dependencies": {
     "@macarie/batch": "^1.2.1",
     "kleur": "^4.1.4",
-    "sade": "^1.7.4"
+    "sade": "^1.7.4",
+    "totalist": "^2.0.0"
   },
   "xo": {
     "prettier": true

--- a/src/bin/bin.ts
+++ b/src/bin/bin.ts
@@ -10,37 +10,90 @@ import { exec } from '../runner/runner.js'
 
 type CLIOptions = {
   cwd: string
+  dir: string | string[]
+  pattern: string | string[]
+  ignore: string | string[]
 }
+
+const toRegExp = (input: string) => new RegExp(input, 'i')
 
 const defaults = {
   dir: '.',
-  patternWithDir: /\.m?js$/i,
-  patternWithoutDir: /(^(tests?|__tests?__)[\\/].+|[-.](test|spec)?)\.js$/i,
+  patternWithDir: [/\.m?js$/i],
+  patternWithoutDir: [/(^(tests?|__tests?__)[\\/].+|[-.](test|spec)?)\.js$/i],
   ignoredPaths: [/node_modules/i],
 }
 
-sade('test-please [dir] [pattern]')
-  .option('-C, --cwd', 'The current directory to resolve from', cwd())
-  .action(async (dir: string, pattern: string, options: CLIOptions) => {
-    const dirToUse = dir || defaults.dir
-    const patternToUse: RegExp = pattern
-      ? new RegExp(pattern, 'i')
-      : dir
-      ? defaults.patternWithDir
-      : defaults.patternWithoutDir
+const getDir = (dir: string | string[] = defaults.dir) => {
+  if (Array.isArray(dir)) {
+    return dir
+  }
 
-    const { ignoredPaths } = defaults
+  return [dir]
+}
+
+const getPattern = (pattern: string | string[], dir?: string | string[]) => {
+  if (pattern === undefined) {
+    if (dir === undefined) {
+      return defaults.patternWithoutDir
+    }
+
+    return defaults.patternWithDir
+  }
+
+  if (Array.isArray(pattern)) {
+    return pattern.map((p) => toRegExp(p))
+  }
+
+  return [toRegExp(pattern)]
+}
+
+const getIgnored = (ignored: string | string[]) => {
+  if (ignored === undefined) {
+    return defaults.ignoredPaths
+  }
+
+  if (Array.isArray(ignored)) {
+    return [...defaults.ignoredPaths, ...ignored.map((i) => toRegExp(i))]
+  }
+
+  return [...defaults.ignoredPaths, toRegExp(ignored)]
+}
+
+sade('test-please', true)
+  .option(
+    '-C, --cwd',
+    'The location from which lookups should be resolved',
+    cwd()
+  )
+  .option('-d, --dir', "The test files' location")
+  .option(
+    '-p, --pattern',
+    "A pattern that the test files' path should match to be executed"
+  )
+  .option(
+    '-i, --ignore',
+    'A pattern used to ignore files, `node_modules` is always ignored'
+  )
+  .action(async (options: CLIOptions) => {
+    const dirs: string[] = getDir(options.dir)
+    const patterns: RegExp[] = getPattern(options.pattern, options.dir)
+    const ignored: RegExp[] = getIgnored(options.ignore)
 
     const tests: string[] = []
 
-    await totalist(resolvePath(options.cwd, dirToUse), (relativePath) => {
-      if (
-        !ignoredPaths.every((ignoredPath) => ignoredPath.test(relativePath)) &&
-        patternToUse.test(relativePath)
-      ) {
-        tests.push(resolvePath(dirToUse, relativePath))
-      }
-    })
+    await Promise.all(
+      dirs.map(async (dir) =>
+        totalist(resolvePath(options.cwd, dir), (relativePath) => {
+          if (
+            !ignored.every((ignoredPath) => ignoredPath.test(relativePath)) &&
+            patterns.some((pattern) => pattern.test(relativePath))
+          ) {
+            tests.push(resolvePath(dir, relativePath))
+          }
+        })
+      )
+    )
 
     try {
       await exec({

--- a/src/bin/bin.ts
+++ b/src/bin/bin.ts
@@ -1,17 +1,50 @@
 #!/usr/bin/env node
 
 import { cwd } from 'node:process'
+import { resolve as resolvePath } from 'node:path'
 
 import sade from 'sade'
+import { totalist } from 'totalist'
 
 import { exec } from '../runner/runner.js'
 
-sade('test-please [tests]')
+type CLIOptions = {
+  cwd: string
+}
+
+const defaults = {
+  dir: '.',
+  patternWithDir: /\.m?js$/i,
+  patternWithoutDir: /(^(tests?|__tests?__)[\\/].+|[-.](test|spec)?)\.js$/i,
+  ignoredPaths: [/node_modules/i],
+}
+
+sade('test-please [dir] [pattern]')
   .option('-C, --cwd', 'The current directory to resolve from', cwd())
-  .action(async (tests: string | string[], options: { cwd: string }) => {
+  .action(async (dir: string, pattern: string, options: CLIOptions) => {
+    const dirToUse = dir || defaults.dir
+    const patternToUse: RegExp = pattern
+      ? new RegExp(pattern, 'i')
+      : dir
+      ? defaults.patternWithDir
+      : defaults.patternWithoutDir
+
+    const { ignoredPaths } = defaults
+
+    const tests: string[] = []
+
+    await totalist(resolvePath(options.cwd, dirToUse), (relativePath) => {
+      if (
+        !ignoredPaths.every((ignoredPath) => ignoredPath.test(relativePath)) &&
+        patternToUse.test(relativePath)
+      ) {
+        tests.push(resolvePath(dirToUse, relativePath))
+      }
+    })
+
     try {
       await exec({
-        tests: Array.isArray(tests) ? tests : [tests],
+        tests,
         workingDirectory: options.cwd,
       })
     } catch {


### PR DESCRIPTION
Should fix #3.

I'm not convinced about the change, though.

It works, but does it provide a good experience?
- it's impossible to specify a different pattern without having a base directory;
- it's impossible to have more than one base directory;
- `pattern` might end up being a behemoth of a regular expression in more complex scenarios.